### PR TITLE
Fixed bug in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GDAL_LDFLAGS = `gdal-config --libs`
 
 CC = gcc
 CFLAGS = -Wall -Wextra -ansi -pedantic -std=c99 -O2 $(GDAL_CFLAGS)
-LDFLAGS = $(GDAL_LDFLAGS)
+LDFLAGS = $(GDAL_LDFLAGS) -lm
 
 all: gdaldem_web
 


### PR DESCRIPTION
-lm was missing

Without this I got an error in GCC 5.3.0:

```
gcc -Wall -Wextra -ansi -pedantic -std=c99 -O2 `gdal-config --cflags`  `gdal-config --libs`   gdaldem_web.c   -o gdaldem_web
/usr/bin/ld: /tmp/ccAJTcWc.o: undefined reference to symbol 'floorf@@GLIBC_2.2.5'
/usr/lib/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
<builtin>: recipe for target 'gdaldem_web' failed
make: *** [gdaldem_web] Error 
```
